### PR TITLE
ldd: remove printing of file

### DIFF
--- a/glibc/ldd
+++ b/glibc/ldd
@@ -105,8 +105,6 @@ done
 for file in "$@"; do
     [ "${file#/}" = "$file" ] && file="./$file"
 
-    printf '%s:\n' "$file"
-
     if [ ! -e "$file" ]; then
         printf "%s: %s: No such file or directory\n" "$0" "$file" >&2
         result=1


### PR DESCRIPTION
```
illiliti: yeah
illiliti: is is bug in sh-alternatives
wael: what is the fix?
illiliti: https://github.com/kiss-community/sh-alternatives/blob/master/glibc/ldd#L108
illiliti: remove this
illiliti: glibc ldd doesn't print it and i see no point why it should
```
related: 
https://termbin.com/rtdv